### PR TITLE
fix: compilation for 5.5 by updating build settings

### DIFF
--- a/Source/ToolExampleEditor.Target.cs
+++ b/Source/ToolExampleEditor.Target.cs
@@ -8,7 +8,7 @@ public class ToolExampleEditorTarget : TargetRules
 	public ToolExampleEditorTarget(TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Editor;
-        DefaultBuildSettings = BuildSettingsVersion.V2;
+        DefaultBuildSettings = BuildSettingsVersion.V5;
         IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 
         ExtraModuleNames.AddRange( new string[] { "ToolExample" } );

--- a/ToolExample.uproject
+++ b/ToolExample.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "5.2",
+	"EngineAssociation": "5.5",
 	"Category": "",
 	"Description": "",
 	"Modules": [


### PR DESCRIPTION
Build settings V2 has some settings that are no longer supported by the current Unreal Engine version, like still using cpp version 17. Build settings V5 fixes this, but keep in mind this updates cpp version from 17 to 20, which might invalidate some legacy API.