### PR TITLE
fix: update Discord invite URL to correct server link

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ A couple of other good resources for getting started:
 
 ## Support/Contact
 - Feel free to reach out to me on the [Unreal Slackers](https://discord.gg/unreal-slackers) discord.  I'm @Fragmanget_.  There is also a ton of other Unreal programmers up there, so if I'm not around to help, someone else be able to get you going.
-- You can also reach me on my personal [Discord Server](https://discord.gg/TSKHvVFYxB) (@cptvideo), via [LinkedIn](https://www.linkedin.com/in/scottkirvan/), or <a href="mailto:ToolExample@skvfx.com">email</a>.
+- You can also reach me on my personal [Discord Server](https://discord.gg/TN6XJSNK5Y) (@cptvideo), via [LinkedIn](https://www.linkedin.com/in/scottkirvan/), or <a href="mailto:ToolExample@skvfx.com">email</a>.
 
 ## Submit a Feature Request
 Use the [Issues](https://github.com/ScottKirvan/ToolExample/issues) link, above.  Thanks!


### PR DESCRIPTION
## Summary
- Updates Discord invite URL from `discord.gg/TSKHvVFYxB` to the correct `discord.gg/TN6XJSNK5Y` across all markdown and workflow files

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
**Steps to verify:**
1. Search this repo for `TSKHvVFYxB` — should return no results
2. Confirm Discord links point to `discord.gg/TN6XJSNK5Y`

**Expected result:** All Discord links use the correct invite URL.

**Test environment:**
- GitHub web UI / text search

## Checklist
- [x] I have performed a self-review of my own code
- [x] No stale Discord invite URLs remain in this repo