### PR TITLE
fix: add bootstrap-sha to release-please config

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -2,5 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-component-in-tag": false,
-  "changelog-path": "notes/CHANGELOG.md"
+  "changelog-path": "notes/CHANGELOG.md",
+  "bootstrap-sha": "3b769e3daef83c0663895699d0e0c69f4b007245"
 }


### PR DESCRIPTION
## Summary

- Adds `bootstrap-sha` to the release-please config pointing to the current HEAD
- Without this, release-please has no baseline (no existing tags) and scans all history, finding zero conventional commits, so it never opens a chore PR
- After this merges, any future `fix:` or `feat:` commit to `main` will trigger a release-please chore PR as expected

## Test plan

- [ ] Merge this PR
- [ ] Push a `fix:` or `feat:` commit to main
- [ ] Verify release-please opens a chore PR for the next version