### PR TITLE
fix: add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` to the release workflow so it can be triggered manually (useful when re-running release-please after config changes).

## Changes

- Added `workflow_dispatch:` trigger to `release.yml`

## Test plan

- [ ] Merge this PR — the merge commit to main will trigger release-please with the new v0.1.0 tag anchor in place, which should produce a chore PR bumping the version