### PR TITLE
fix: convert release-please config to packages structure

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -3,5 +3,9 @@
   "release-type": "simple",
   "include-component-in-tag": false,
   "changelog-path": "notes/CHANGELOG.md",
-  "bootstrap-sha": "3b769e3daef83c0663895699d0e0c69f4b007245"
+  "packages": {
+    ".": {
+      "bootstrap-sha": "3b769e3daef83c0663895699d0e0c69f4b007245"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Flat config mode (no `packages` key) doesn't correctly apply `include-component-in-tag` and `bootstrap-sha` when release-please resolves package paths to release tags. Both BojuBot and ReleasePleaseTest use explicit `packages` structure — this aligns ToolExample with that pattern.

## Changes

- Converted root-level release-please settings to `packages: { ".": { ... } }` structure
- Moved `bootstrap-sha` inside the `"."` package entry

## Test plan

- [ ] Merge this PR — the merge commit to main triggers release-please, which should now correctly match the `v0.1.0` tag to the `"."` package and produce a chore PR bumping to `0.1.1`