### PR TITLE
fix: add emoji input to discord-notify job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,4 +51,5 @@ jobs:
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       project_name: "ToolExample"
+      emoji: "🧑‍🎓"
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,13 @@ jobs:
         📖 [User Guide](https://www.scottkirvan.com/ToolExample/) · 🐛 [Report an Issue](https://github.com/ScottKirvan/ToolExample/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/ToolExample/issues/new?template=feature_request.md) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y)
     secrets: inherit
 
+  update-changelog-prs:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ScottKirvan/.github/.github/workflows/reusable-update-changelog-prs.yml@main
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+
   discord-notify:
     needs: [release-please, improve-release-notes]
     if: ${{ needs.release-please.outputs.release_created }}

--- a/README.md
+++ b/README.md
@@ -109,4 +109,6 @@ Contributors:
 [duyaokun](https://github.com/duyaokun) (2024)
 You! (Future!)
 
+[CHANGELOG](notes/CHANGELOG.md)
+
 _ToolExample is licensed under the [MIT License](LICENSE.md)._


### PR DESCRIPTION
## Summary
- Passes `emoji: "🧑‍🎓"` to `reusable-discord-notify.yml` for ToolExample Discord announcements

## Notes
Depends on [ScottKirvan/.github#8](https://github.com/ScottKirvan/.github/pull/8) being merged first — that PR adds the `emoji` input to the reusable workflow. Merge order: `.github#8` → these three PRs.

## Test plan
- [ ] Merge ScottKirvan/.github#8 first
- [ ] Merge this PR
- [ ] Trigger a release and verify Discord message shows 🧑‍🎓 instead of 🚀